### PR TITLE
Use centralized reusable CI workflows

### DIFF
--- a/.github/workflows/test_manual_dependency_version.yml
+++ b/.github/workflows/test_manual_dependency_version.yml
@@ -1,0 +1,74 @@
+on:
+  workflow_dispatch:
+    inputs:
+      library:
+        description: "Dependency library name to test (e.g. numpy)"
+        required: true
+        type: string
+      min_version:
+        description: "Minimum (lower-bound) version to test (optional)"
+        required: false
+        type: string
+        default: ""
+      max_version:
+        description: "Maximum (upper-bound) version to test (optional)"
+        required: false
+        type: string
+        default: ""
+      runner_tag:
+        description: "Runner to execute the tests on (e.g. self-hosted, ubuntu-latest)"
+        required: true
+        type: string
+        default: "self-hosted"
+      additional_conda_channel:
+        description: "Additional conda channel to search for packages (e.g. 'gurobi'). When provided, it is passed to the test workflow via -c flag."
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  # Resolve the line position of the library inside requirements-dev.yml so
+  # the test workflow knows which entry to override.
+  extract-position:
+    uses: FZJ-IEK3-VSA/.github/.github/workflows/extract_versions.yml@v1
+    with:
+      libraries: ${{ inputs.library }}
+      env_file: requirements-dev.yml
+
+  # Query conda-forge for all versions of the library within the given bounds
+  # and produce a matrix ready for the test workflow.
+  query-versions:
+    needs: extract-position
+    uses: FZJ-IEK3-VSA/.github/.github/workflows/query_conda_versions.yml@v1
+    with:
+      package_name: ${{ inputs.library }}
+      min_version: ${{ inputs.min_version }}
+      max_version: ${{ inputs.max_version }}
+      dependency_position_env_file: ${{ needs.extract-position.outputs.dependency_position }}
+      requirements_file_name: requirements-dev.yml
+      conda_channel: ${{ inputs.additional_conda_channel || 'conda-forge' }}
+
+  TestManualVersions:
+    name: "Test ${{ matrix.library_name }} ${{ matrix.library_version }}"
+    needs: query-versions
+    if: needs.query-versions.outputs.matrix_json != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.query-versions.outputs.matrix_json) }}
+    # glaes needs geokit, so use the extra-repos variant: geokit is checked out,
+    # its requirements-dev.yml is merged with glaes', and both are installed.
+    uses: FZJ-IEK3-VSA/.github/.github/workflows/run_conda_forge_test_with_extra_repos.yml@v1
+    secrets: inherit
+    with:
+      runner_tag: ${{ inputs.runner_tag }}
+      requirements_file_name: ${{ matrix.requirements_file_name }}
+      extra_repos: |
+        [
+          {"repo": "FZJ-IEK3-VSA/geokit"}
+        ]
+      library_name: ${{ matrix.library_name }}
+      library_version: ${{ matrix.library_version }}
+      dependency_position_env_file: ${{ matrix.dependency_position_env_file }}
+      multiprocessing_pytest_string: "-n auto"
+      additional_conda_channel: ${{ inputs.additional_conda_channel }}

--- a/.github/workflows/test_manual_dependency_version.yml
+++ b/.github/workflows/test_manual_dependency_version.yml
@@ -21,54 +21,25 @@ on:
         type: string
         default: "self-hosted"
       additional_conda_channel:
-        description: "Additional conda channel to search for packages (e.g. 'gurobi'). When provided, it is passed to the test workflow via -c flag."
+        description: "Additional conda channel to search for packages (e.g. 'gurobi')."
         required: false
         type: string
         default: ""
 
 jobs:
-  # Resolve the line position of the library inside requirements-dev.yml so
-  # the test workflow knows which entry to override.
-  extract-position:
-    uses: FZJ-IEK3-VSA/.github/.github/workflows/extract_versions.yml@v1
-    with:
-      libraries: ${{ inputs.library }}
-      env_file: requirements-dev.yml
-
-  # Query conda-forge for all versions of the library within the given bounds
-  # and produce a matrix ready for the test workflow.
-  query-versions:
-    needs: extract-position
-    uses: FZJ-IEK3-VSA/.github/.github/workflows/query_conda_versions.yml@v1
-    with:
-      package_name: ${{ inputs.library }}
-      min_version: ${{ inputs.min_version }}
-      max_version: ${{ inputs.max_version }}
-      dependency_position_env_file: ${{ needs.extract-position.outputs.dependency_position }}
-      requirements_file_name: requirements-dev.yml
-      conda_channel: ${{ inputs.additional_conda_channel || 'conda-forge' }}
-
-  TestManualVersions:
-    name: "Test ${{ matrix.library_name }} ${{ matrix.library_version }}"
-    needs: query-versions
-    if: needs.query-versions.outputs.matrix_json != '[]'
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJSON(needs.query-versions.outputs.matrix_json) }}
-    # glaes needs geokit, so use the extra-repos variant: geokit is checked out,
-    # its requirements-dev.yml is merged with glaes', and both are installed.
-    uses: FZJ-IEK3-VSA/.github/.github/workflows/run_conda_forge_test_with_extra_repos.yml@v1
+  # Orchestration lives in the centralized .github repo. glaes only supplies the
+  # repo-specific values: its requirements file and geokit as an extra repo.
+  manual-dependency-test:
+    uses: FZJ-IEK3-VSA/.github/.github/workflows/test_manual_dependency_version.yml@v1
     secrets: inherit
     with:
+      library: ${{ inputs.library }}
+      min_version: ${{ inputs.min_version }}
+      max_version: ${{ inputs.max_version }}
       runner_tag: ${{ inputs.runner_tag }}
-      requirements_file_name: ${{ matrix.requirements_file_name }}
+      requirements_file_name: requirements-dev.yml
       extra_repos: |
         [
           {"repo": "FZJ-IEK3-VSA/geokit"}
         ]
-      library_name: ${{ matrix.library_name }}
-      library_version: ${{ matrix.library_version }}
-      dependency_position_env_file: ${{ matrix.dependency_position_env_file }}
-      multiprocessing_pytest_string: "-n auto"
       additional_conda_channel: ${{ inputs.additional_conda_channel }}

--- a/.github/workflows/test_pull_dev.yml
+++ b/.github/workflows/test_pull_dev.yml
@@ -2,61 +2,22 @@ on:
   pull_request:
     branches: ["dev"]
 
-defaults:
-  run:
-    shell: pwsh
 jobs:
   TestPullCondaForgeDev:
     name: Test development version on ${{ matrix.runner_tag }}
     strategy:
       fail-fast: false
       matrix:
-        runner_tag: [
-            "self-hosted","windows-latest"
-          ]
-        python_version: ["3.10"]
-
-    runs-on: ${{ matrix.runner_tag }}
-    steps:
-      - name: Checkout glaes
-        uses: actions/checkout@v6
-        with:
-          path: "glaes"
-      - name: Checkout geokit
-        uses: actions/checkout@v6
-        with:
-          # Repository name with owner. For example, actions/checkout
-          repository: "FZJ-IEK3-VSA/geokit"
-          path: "geokit"
-      - name: Setup yq 4.30.6
-        uses: vegardit/gha-setup-yq@v1
-        with:
-          use-cache: true
-          version: 4.30.6
-      - name: Merge yaml files
-        run: yq eval-all '. as $item ireduce ({}; . *+ $item)' geokit/requirements-dev.yml glaes/requirements-dev.yml > combined_env.yml
-      - name: Show combined yml
-        run: |
-          get-content combined_env.yml
-      - uses: conda-incubator/setup-miniconda@v3
-        with:
-          miniforge-version: 25.3.0-3
-          channels: conda-forge
-          activate-environment: ""
-          conda-remove-defaults: "true"
-      - name: Setup environment
-        run: |
-          get-content combined_env.yml
-          ls
-          echo "LS Done"
-          mamba env create --name test_env --yes --file combined_env.yml
-          mamba run --name test_env pip install -e ./glaes --no-deps
-          mamba run --name test_env pip install -e ./geokit --no-deps
-          echo "Installation done"
-          mamba list --name test_env
-          echo "packages printed"
-      - name: Run tests
-        run: |
-          echo "start pytest"
-          mamba run --name test_env pytest -n auto  -vv
-          echo "Pytest done"
+        runner_tag: ["self-hosted", "windows-latest"]
+    # geokit is checked out as an extra repo, its requirements-dev.yml is merged
+    # with glaes', and both are installed editable before the tests run.
+    uses: FZJ-IEK3-VSA/.github/.github/workflows/run_conda_forge_test_with_extra_repos.yml@v1
+    secrets: inherit
+    with:
+      runner_tag: ${{ matrix.runner_tag }}
+      requirements_file_name: requirements-dev.yml
+      extra_repos: |
+        [
+          {"repo": "FZJ-IEK3-VSA/geokit"}
+        ]
+      multiprocessing_pytest_string: "-n auto"

--- a/.github/workflows/test_push.yml
+++ b/.github/workflows/test_push.yml
@@ -1,59 +1,24 @@
 on:
-    push:
-        branches: ["**"]
-
-defaults:
-    run:
-        shell: pwsh
+  workflow_dispatch:
+  push:
+    branches: ["**"]
 
 jobs:
-    run-conda-forge-test:
-        name: "Run test for glaes on ${{ matrix.runner_tag }}"
-        strategy:
-            fail-fast: false
-            matrix:
-                runner_tag: ["self-hosted"]
-        runs-on: ${{ matrix.runner_tag }}
-        steps:
-            - name: Checkout glaes
-              uses: actions/checkout@v5
-              with:
-                  path: "glaes"
-            - name: Checkout geokit
-              uses: actions/checkout@v6
-              with:
-                  # Repository name with owner. For example, actions/checkout
-                  repository: "FZJ-IEK3-VSA/geokit"
-                  path: "geokit"
-            - name: Setup yq 4.30.6
-              uses: vegardit/gha-setup-yq@v1
-              with:
-                  use-cache: true
-                  version: 4.30.6
-            - name: Merge yaml files
-              run: yq eval-all '. as $item ireduce ({}; . *+ $item)' geokit/requirements-dev.yml glaes/requirements-dev.yml > combined_env.yml
-            - name: Show combined yml
-              run: |
-                  get-content combined_env.yml
-            - uses: conda-incubator/setup-miniconda@v3
-              with:
-                  miniforge-version: 25.3.0-3
-                  channels: conda-forge
-                  activate-environment: ""
-                  conda-remove-defaults: "true"
-            - name: Setup environment
-              run: |
-                  get-content combined_env.yml
-                  ls
-                  echo "LS Done"
-                  mamba env create --name test_env --yes --file combined_env.yml
-                  mamba run --name test_env pip install -e ./glaes --no-deps
-                  mamba run --name test_env pip install -e ./geokit --no-deps
-                  echo "Installation done"
-                  mamba list --name test_env
-                  echo "packages printed"
-            - name: Run tests
-              run: |
-                  echo "start pytest"
-                  mamba run --name test_env pytest -n auto  -vv
-                  echo "Pytest done"
+  TestPushCondaForgeDev:
+    name: Test conda-forge development version on ${{ matrix.runner_tag }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner_tag: ["self-hosted"]
+    # geokit is checked out as an extra repo, its requirements-dev.yml is merged
+    # with glaes', and both are installed editable before the tests run.
+    uses: FZJ-IEK3-VSA/.github/.github/workflows/run_conda_forge_test_with_extra_repos.yml@v1
+    secrets: inherit
+    with:
+      runner_tag: ${{ matrix.runner_tag }}
+      requirements_file_name: requirements-dev.yml
+      extra_repos: |
+        [
+          {"repo": "FZJ-IEK3-VSA/geokit"}
+        ]
+      multiprocessing_pytest_string: "-n auto"


### PR DESCRIPTION
Replace the inline conda-forge test steps in test_push.yml and test_pull_dev.yml with calls to the centralized reusable workflow FZJ-IEK3-VSA/.github/.github/workflows/run_conda_forge_test_with_extra_repos.yml@v1, which checks out geokit as an extra repo, merges requirements-dev.yml, and installs both editable.

Add test_manual_dependency_version.yml (adapted from FINE) to manually test glaes against specific conda-forge versions of a dependency.