### PR TITLE
Remove trailing whitespace in recipe.yaml

### DIFF
--- a/recipe.yaml
+++ b/recipe.yaml
@@ -27,13 +27,13 @@ requirements:
   - pandas >=1.4.0,<=3.0.3
   - numpy >=1.26.0,<=2.5.0
   - scipy >=1.10.0,<1.18.0
-  - geokit >=1.7.1,<=1.9.0 
+  - geokit >=1.7.1,<=1.9.0
   # dev
   - pytest <=9.1.1
   - pytest-xdist <=3.8.0
   - pytest-cov <=7.1.0
   - ruff =0.14.1
-  - nbval <=0.11.0 
+  - nbval <=0.11.0
 
 
 


### PR DESCRIPTION
Trims trailing whitespace on two run-dependency lines in `recipe.yaml` (`geokit` and `nbval`). Cosmetic, whitespace-only change — no dependency ranges or behavior altered.

```diff
-  - geokit >=1.7.1,<=1.9.0 
+  - geokit >=1.7.1,<=1.9.0
...
-  - nbval <=0.11.0 
+  - nbval <=0.11.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)