### PR TITLE
169 axial direction definition

### DIFF
--- a/Examples/01_placement_algorithm.ipynb
+++ b/Examples/01_placement_algorithm.ipynb
@@ -226,8 +226,13 @@
    "source": [
     "# reset the ec object again\n",
     "ec = copy(ec_backup)\n",
-    "# do placements with \"separation=(axial, transverse), axialDirection\"\n",
-    "ec.distributeItems(separation=(800, 600), axialDirection=45, avoidRegionBorders=True)\n",
+    "# do placements with \"separation=(axial, transverse)\n",
+    "# NOTE: axialDirection here (as it is the default) in a mathematical polar angle definition,\n",
+    "# counterclockwise from East=0°, pointing away from zero - can also be defined in a \"meteorological\"\n",
+    "# convention as clockwise from North = 0° (like ERA-5 weather reanalaysis data does)\n",
+    "ec.distributeItems(\n",
+    "    separation=(800, 600), axialDirection=45, avoidRegionBorders=True, axialDirectionConvention=\"mathematical\"\n",
+    ")\n",
     "\n",
     "# Draw result\n",
     "ec.draw()"

--- a/glaes/core/ExclusionCalculator.py
+++ b/glaes/core/ExclusionCalculator.py
@@ -1482,7 +1482,16 @@ class ExclusionCalculator(object):
             + f"({basename(sourcePath)}/where: {where}/buffer: {buffer if isinstance(buffer, int) else 0}m), "
         )
 
-    def excludePoints(s, source, geometryShape, scale=None, where=None, direction=None, directionConvention="mathematical", saveToEC=None):
+    def excludePoints(
+        s,
+        source,
+        geometryShape,
+        scale=None,
+        where=None,
+        direction=None,
+        directionConvention="mathematical",
+        saveToEC=None,
+    ):
         """Exclude points with different buffer shapes.
 
         Parameters
@@ -1505,8 +1514,8 @@ class ExclusionCalculator(object):
                 wanted, the correct statement would be:
                     where="type='protected'", by default None
         direction : str or int, optional
-            scalar orientation of the buffer geometry in degrees or name of the dataframe 
-            column that contains the orientation per point, will define the main axis of the exclusion shape, 
+            scalar orientation of the buffer geometry in degrees or name of the dataframe
+            column that contains the orientation per point, will define the main axis of the exclusion shape,
             by default None
         directionConvention : str, optional
             The definition of the "direction" value, the following options are allowed:
@@ -1580,7 +1589,7 @@ class ExclusionCalculator(object):
                 _direction = (270 - _direction) % 360
             else:
                 raise ValueError(f"Unknown directionConvention={directionConvention}")
-            
+
             coor = gk.srs.xyTransform(
                 np.array([[row["geom"].GetX(), row["geom"].GetY()]]),
                 fromSRS=row["geom"].GetSpatialReference(),

--- a/glaes/core/ExclusionCalculator.py
+++ b/glaes/core/ExclusionCalculator.py
@@ -1482,7 +1482,7 @@ class ExclusionCalculator(object):
             + f"({basename(sourcePath)}/where: {where}/buffer: {buffer if isinstance(buffer, int) else 0}m), "
         )
 
-    def excludePoints(s, source, geometryShape, scale=None, where=None, direction=None, saveToEC=None):
+    def excludePoints(s, source, geometryShape, scale=None, where=None, direction=None, directionConvention="mathematical", saveToEC=None):
         """Exclude points with different buffer shapes.
 
         Parameters
@@ -1504,8 +1504,15 @@ class ExclusionCalculator(object):
                 called 'type' and only features with the type "protected" are
                 wanted, the correct statement would be:
                     where="type='protected'", by default None
-        direction : int, optional
-            orientation of the buffer geometry in degrees, by default None
+        direction : str or int, optional
+            scalar orientation of the buffer geometry in degrees or name of the dataframe 
+            column that contains the orientation per point, will define the main axis of the exclusion shape, 
+            by default None
+        directionConvention : str, optional
+            The definition of the "direction" value, the following options are allowed:
+            - mathematical: Counterclockwise from East = 0°, pointing TO direction (away from (0,0))
+            - meteorological : Clockwise from North = 0°, coming FROM direction (pointing towards the opposite direction)
+            By default "mathematical".
         saveToEC : str, optional
             name for points in ec plot, by default None. The points are only
             saved if a string is passed.
@@ -1561,6 +1568,19 @@ class ExclusionCalculator(object):
                 _direction = direction
             else:
                 raise GlaesError("Direction has to be defined.")
+            # make numerical
+            _direction = float(_direction)
+
+            # now align direction with the expected mathematical convention if needed
+            if directionConvention == "mathematical":
+                # this is the standard polar angle coordinate definition that below algorithm expects
+                pass
+            elif directionConvention == "meteorological":
+                # we first need to convert meteorological North=0° CW definition to "mathematical" polar coordinates (CCW from E=0°)
+                _direction = (270 - _direction) % 360
+            else:
+                raise ValueError(f"Unknown directionConvention={directionConvention}")
+            
             coor = gk.srs.xyTransform(
                 np.array([[row["geom"].GetX(), row["geom"].GetY()]]),
                 fromSRS=row["geom"].GetSpatialReference(),

--- a/glaes/core/ExclusionCalculator.py
+++ b/glaes/core/ExclusionCalculator.py
@@ -1955,6 +1955,7 @@ class ExclusionCalculator(object):
         minArea=100000,
         maxAcceptableDistance=None,
         axialDirection=None,
+        axialDirectionConvention="mathematical",
         sepScaling=None,
         _voronoiBoundaryPoints=10,
         _voronoiBoundaryPadding=5,
@@ -1987,6 +1988,12 @@ class ExclusionCalculator(object):
                 - float : The direction to apply to all points
                 - np.ndarray : The directions at each pixel (must match availability matrix shape)
                 - str : A path to a raster file containing axial directions
+
+            axialDirectionConvention : str, optional
+                The definition of the "axialDirection" value, the following options are allowed:
+                - mathematical: Counterclockwise from East = 0°, pointing TO direction (away from (0,0))
+                - meteorological : Clockwise from North = 0°, coming FROM direction (pointing towards the opposite direction)
+                By default "mathematical".
 
             maxAcceptableDistance : A maximum distance to allow between items
                 - Computes a post-placement distance matrix for the located placements
@@ -2062,6 +2069,14 @@ class ExclusionCalculator(object):
                 axialDirection = float(axialDirection)
 
             # we now have the axialDirection in degrees in all cases
+            if axialDirectionConvention == "mathematical":
+                # this is the standard polar angle coordinate definition that below algorithm expects
+                pass
+            elif axialDirectionConvention == "meteorological":
+                # we first need to convert meteorological North=0° CW definition to "mathematical" polar coordinates (CCW from E=0°)
+                axialDirection = (270 - axialDirection) % 360
+            else:
+                raise ValueError(f"Unknown axialDirectionConvention={axialDirectionConvention}")
 
             useGradient = True
         else:

--- a/glaes/core/ExclusionCalculator.py
+++ b/glaes/core/ExclusionCalculator.py
@@ -2054,12 +2054,14 @@ class ExclusionCalculator(object):
         if axialDirection is not None:
             if isinstance(axialDirection, str):  # Assume a path to a raster file is given
                 axialDirection = s.region.warp(axialDirection, resampleAlg="near")
-            # Assume a path to a raster file is given
+            # Assume direction data is given as an array matching the region mask "chess board"
             elif isinstance(axialDirection, np.ndarray):
                 if not axialDirection.shape == s.region.mask.shape:
                     raise GlaesError("axialDirection matrix does not match context")
-            else:  # axialDirection should be a single value
-                axialDirection = np.radians(float(axialDirection))
+            else:  # axialDirection should be a single degree value
+                axialDirection = float(axialDirection)
+
+            # we now have the axialDirection in degrees in all cases
 
             useGradient = True
         else:
@@ -2212,9 +2214,11 @@ class ExclusionCalculator(object):
                 # only continue if there are no points in the immediate range of the whole pixel
                 if useGradient:
                     if isinstance(axialDirection, np.ndarray):
-                        grad = np.radians(axialDirection[yi, xi])
+                        grad = axialDirection[yi, xi]
                     else:
                         grad = axialDirection
+                    # Convert centrally to radians
+                    grad = np.radians(grad)
 
                     cG = np.cos(grad)
                     sG = np.sin(grad)

--- a/glaes/test/test_ExclusionCalculator.py
+++ b/glaes/test/test_ExclusionCalculator.py
@@ -512,6 +512,11 @@ def test_ExclusionCalculator_distributeItems():
     points = ec.distributeItems(separation=(8, 3), sepScaling=ras, axialDirection=0)
     assert points.shape[0] == 390
 
+    points_meteo = ec.distributeItems(
+        separation=(8, 3), sepScaling=ras, axialDirection=0, axialDirectionConvention="meteorological"
+    )
+    assert points_meteo.shape[0] == 347
+
 
 def test_ExclusionCalculator_distributeAreas():
     # make a prior source

--- a/glaes/test/test_ExclusionCalculator.py
+++ b/glaes/test/test_ExclusionCalculator.py
@@ -43,6 +43,9 @@ def test_excludePoints():
     ec1.excludePoints(source=pointData, geometryShape="rectangle", direction=25)
     assert np.isclose(ec1.percentAvailable, 94.36879792512404)
     assert len(ec1._additionalPoints["Test"]["points"]) == 13
+    ec1.excludePoints(source=pointData, geometryShape="rectangle", direction=25, directionConvention="meteorological")
+    assert np.isclose(ec1.percentAvailable, 93.40888588182229)
+    assert len(ec1._additionalPoints["Test"]["points"]) == 13
 
 
 def test_ExclusionCalculator___init__():


### PR DESCRIPTION
Adds a feature that accepts axial directions also in a meteorological convention which allows to directly use e.g. wind direction raster data from ERA-5 etc.